### PR TITLE
Fix compile error from assigning constant length

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -324,8 +324,6 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
-
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 


### PR DESCRIPTION
This fixes the following error when compiling with clang19:
```
rapidjson/rapidjson/document.h:319:82: error: cannot assign to non-static data member 'length' with const-qualified type 'const SizeType' (aka 'const unsigned int')
  319 |     GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
      |                                                                           ~~~~~~ ^
rapidjson/rapidjson/document.h:325:20: note: non-static data member 'length' declared const here
  325 |     const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
      |     ~~~~~~~~~~~~~~~^~~~~~
1 error generated.
```
The operator= is to a class with only const fields and is also unused. This definition was removed.